### PR TITLE
fixes typo, adds google analytics back in

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -101,6 +101,17 @@
 	  }
 	}, 1000);
 </script>
+
+<script>
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+  ga('create', 'UA-100151074-1', 'auto');
+  ga('send', 'pageview');
+
+</script>
   </head>
 
   <body>
@@ -109,7 +120,7 @@
 
       <div class="row">
         <h1 class="text-center">Neohabitat</h1>
-        <p>Neohabitat is a relaunch of the first massively mulitplayer online roleplaying game, Lucasfilm's Habitat. Originally developed in 1985 by Lucasfilm Games (now Lucas Arts) for the Commodore 64, Habitat is considered the grandfather of modern MMORPGs. Neohabitat is an open-source project led by Randy Farmer, one of Habitats creators, reviving the original Habitat world.</p>
+        <p>Neohabitat is a relaunch of the first massively mulitplayer online roleplaying game, Lucasfilm's Habitat. Originally developed in 1985 by Lucasfilm Games (now Lucas Arts) for the Commodore 64, Habitat is considered the grandfather of modern MMORPGs. Neohabitat is an open-source project led by Randy Farmer, one of Habitat's creators, reviving the original Habitat world.</p>
       </div>
 
       <div class="row">


### PR DESCRIPTION
Accidentally removed the google analytics in the previous PR. This adds it back in and adds the apostrophe to "Habitat's creator"